### PR TITLE
Encode query values

### DIFF
--- a/BeatSaverSharp/BeatSaver.cs
+++ b/BeatSaverSharp/BeatSaver.cs
@@ -10,6 +10,7 @@ using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Web;
 
 namespace BeatSaverSharp
 {
@@ -161,7 +162,9 @@ namespace BeatSaverSharp
                         // DateTimes need to be formatted to conform to ISO
                         if (filterValue is DateTime dateTime)
                             filterValue = dateTime.ToString("yyyy-MM-ddTHH:mm:ssZ"); // yyyy-MM-dd
-                        queryProps.Add($"{property.Item1}={filterValue}");
+
+                        var encoded = HttpUtility.UrlEncode(filterValue.ToString(), Encoding.Default);
+                        queryProps.Add($"{property.Item1}={encoded}");
                     }
                 }
 


### PR DESCRIPTION
I've seen a small number of people searching for things like "3%" or "100%" as these are not urlencoded when added to the query string the server gets confused trying to parse an encoded token at the end of input.

This also fixes dumb injection like the following from being treated as new query params:
![image](https://user-images.githubusercontent.com/534069/136621230-04391791-c23c-425c-a904-32426339b047.png)