### PR TITLE
Cache improvements

### DIFF
--- a/BeatSaverSharp.Tests/ByHashTests.cs
+++ b/BeatSaverSharp.Tests/ByHashTests.cs
@@ -34,7 +34,7 @@ namespace BeatSaverSharp.Tests
             // Kanaria - Envy Baby (Will Stetson Cover)
             //  CoolingCloset & Nolanimations
             //  April 14th, 2021
-            var envyBaby = results["4529498dab9d920c1e7a3ba46507b677655b3ad7"];
+            var envyBaby = results["4529498DAB9D920C1E7A3BA46507B677655B3AD7"];
             Assert.IsNotNull(envyBaby);
             Assert.IsNotNull(envyBaby.Uploader);
 
@@ -44,7 +44,7 @@ namespace BeatSaverSharp.Tests
             // EGOIST - RELOADED (Short Ver.)
             //  CoolingCloset
             //  January 18th, 2021
-            var reloaded = results["701587ce2d1e502f8352c3cfd0627c1844b0ff0a"];
+            var reloaded = results["701587CE2D1E502F8352C3CFD0627C1844B0FF0A"];
             Assert.IsNotNull(reloaded);
             Assert.IsNotNull(reloaded.Uploader);
             Assert.IsNull(reloaded.Uploader.Stats);

--- a/BeatSaverSharp.Tests/ByHashTests.cs
+++ b/BeatSaverSharp.Tests/ByHashTests.cs
@@ -34,7 +34,7 @@ namespace BeatSaverSharp.Tests
             // Kanaria - Envy Baby (Will Stetson Cover)
             //  CoolingCloset & Nolanimations
             //  April 14th, 2021
-            var envyBaby = results["4529498DAB9D920C1E7A3BA46507B677655B3AD7"];
+            var envyBaby = results["4529498dab9d920c1e7a3ba46507b677655b3ad7"];
             Assert.IsNotNull(envyBaby);
             Assert.IsNotNull(envyBaby.Uploader);
 
@@ -44,7 +44,7 @@ namespace BeatSaverSharp.Tests
             // EGOIST - RELOADED (Short Ver.)
             //  CoolingCloset
             //  January 18th, 2021
-            var reloaded = results["701587CE2D1E502F8352C3CFD0627C1844B0FF0A"];
+            var reloaded = results["701587ce2d1e502f8352c3cfd0627c1844b0ff0a"];
             Assert.IsNotNull(reloaded);
             Assert.IsNotNull(reloaded.Uploader);
             Assert.IsNull(reloaded.Uploader.Stats);

--- a/BeatSaverSharp/BeatSaver.cs
+++ b/BeatSaverSharp/BeatSaver.cs
@@ -29,7 +29,7 @@ namespace BeatSaverSharp
         private readonly ConcurrentDictionary<int, User> _fetchedUsers = new ConcurrentDictionary<int, User>();
         private readonly ConcurrentDictionary<string, User> _fetchedUsernames = new ConcurrentDictionary<string, User>();
         private readonly ConcurrentDictionary<string, Beatmap> _fetchedBeatmaps = new ConcurrentDictionary<string, Beatmap>();
-        private readonly ConcurrentDictionary<string, Beatmap> _fetchedHashedBeatmaps = new ConcurrentDictionary<string, Beatmap>();
+        private readonly ConcurrentDictionary<string, Beatmap> _fetchedHashedBeatmaps = new ConcurrentDictionary<string, Beatmap>(StringComparer.OrdinalIgnoreCase);
 
         static BeatSaver()
         {
@@ -106,7 +106,7 @@ namespace BeatSaverSharp
                             var song = await BeatmapByHash(asList.First(), token);
                             if (song != null)
                             {
-                                result[song.LatestVersion.Hash.ToUpperInvariant()] = song;
+                                result[song.LatestVersion.Hash] = song;
                             }
                         }
                         else
@@ -116,7 +116,7 @@ namespace BeatSaverSharp
                             if (newBeatmaps == null) continue;
                             foreach (var keyValuePair in newBeatmaps)
                             {
-                                result[keyValuePair.Key.ToUpperInvariant()] = keyValuePair.Value;
+                                result[keyValuePair.Key] = keyValuePair.Value;
                             }
                         }
                     }
@@ -130,7 +130,6 @@ namespace BeatSaverSharp
         {
             if (string.IsNullOrWhiteSpace(hash))
                 return null;
-            hash = hash.ToUpperInvariant();
 
             if (!skipCacheCheck && _fetchedHashedBeatmaps.TryGetValue(hash, out Beatmap? beatmap))
                 return beatmap;
@@ -474,12 +473,12 @@ namespace BeatSaverSharp
 
                     foreach (var version in beatmap.Versions)
                     {
-                        _fetchedHashedBeatmaps.TryAdd(version.Hash.ToUpperInvariant(), beatmap);
+                        _fetchedHashedBeatmaps.TryAdd(version.Hash, beatmap);
                     }
 
                     if (hash != null && !beatmap.Versions.Any(x => string.Equals(x.Hash, hash, StringComparison.OrdinalIgnoreCase)))
                     {
-                        _fetchedHashedBeatmaps.TryAdd(hash.ToUpperInvariant(), beatmap);
+                        _fetchedHashedBeatmaps.TryAdd(hash, beatmap);
                     }
 
                     PopulateWithClient(cachedAndOrBeatmap);

--- a/BeatSaverSharp/BeatSaver.cs
+++ b/BeatSaverSharp/BeatSaver.cs
@@ -78,7 +78,7 @@ namespace BeatSaverSharp
 
         public async Task<Dictionary<string, Beatmap>> BeatmapByHash(string[] hashes, CancellationToken token = default, bool skipCacheCheck = false)
         {
-            var grouped = hashes.GroupBy(x => !skipCacheCheck && _fetchedBeatmaps.ContainsKey(x));
+            var grouped = hashes.GroupBy(x => !skipCacheCheck && _fetchedHashedBeatmaps.ContainsKey(x));
             var result = new Dictionary<string, Beatmap>();
             foreach (var grouping in grouped)
             {
@@ -87,7 +87,7 @@ namespace BeatSaverSharp
                     // In cache
                     foreach (var s in grouping)
                     {
-                        result.Add(s, _fetchedBeatmaps[s]);
+                        result.Add(s, _fetchedHashedBeatmaps[s]);
                     }
                 }
                 else

--- a/BeatSaverSharp/BeatSaver.cs
+++ b/BeatSaverSharp/BeatSaver.cs
@@ -477,7 +477,7 @@ namespace BeatSaverSharp
                         _fetchedHashedBeatmaps.TryAdd(version.Hash.ToUpperInvariant(), beatmap);
                     }
 
-                    if (hash != null && !beatmap.Versions.Any(x => string.Equals(x.Hash, hash, StringComparison.InvariantCultureIgnoreCase)))
+                    if (hash != null && !beatmap.Versions.Any(x => string.Equals(x.Hash, hash, StringComparison.OrdinalIgnoreCase)))
                     {
                         _fetchedHashedBeatmaps.TryAdd(hash.ToUpperInvariant(), beatmap);
                     }

--- a/BeatSaverSharp/BeatSaver.cs
+++ b/BeatSaverSharp/BeatSaver.cs
@@ -79,7 +79,7 @@ namespace BeatSaverSharp
         public async Task<Dictionary<string, Beatmap>> BeatmapByHash(string[] hashes, CancellationToken token = default, bool skipCacheCheck = false)
         {
             var grouped = hashes.Select(x => x.ToUpperInvariant()).Distinct().GroupBy(x => !skipCacheCheck && _fetchedHashedBeatmaps.ContainsKey(x));
-            var result = new Dictionary<string, Beatmap>();
+            var result = new Dictionary<string, Beatmap>(StringComparer.OrdinalIgnoreCase);
             foreach (var grouping in grouped)
             {
                 if (grouping.Key)


### PR DESCRIPTION
The old BeatmapByHash method was uppercasing all hashes but then when they were added to the cache the api response was used which is currently always lowercase. This renders the cache useless.

Happy to standardise either way but this causes all hashes to be cached uppercase in BeatSaverSharper.

Additionally when maps have been updated they were only cached against their new hash. This PR adds a cache key for the hash used for the lookup.