### PR TITLE
Add support for new Curator object

### DIFF
--- a/BeatSaverSharp/BeatSaver.cs
+++ b/BeatSaverSharp/BeatSaver.cs
@@ -434,9 +434,6 @@ namespace BeatSaverSharp
                     if (beatmap.Automapper != cachedBeatmap.Automapper)
                         cachedBeatmap.Automapper = beatmap.Automapper;
 
-                    if (beatmap.Curator != cachedBeatmap.Curator)
-                        cachedBeatmap.Curator = beatmap.Curator;
-
                     if (beatmap.Description != cachedBeatmap.Description)
                         cachedBeatmap.Description = beatmap.Description;
 

--- a/BeatSaverSharp/Models/Beatmap.cs
+++ b/BeatSaverSharp/Models/Beatmap.cs
@@ -81,7 +81,7 @@ namespace BeatSaverSharp.Models
         /// The person who curated this map.
         /// </summary>
         [JsonProperty("curator")]
-        public string? Curator { get; internal set; }
+        public Curator? Curator { get; internal set; }
 
         private BeatmapVersion? _latestVersion;
 

--- a/BeatSaverSharp/Models/Curator.cs
+++ b/BeatSaverSharp/Models/Curator.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace BeatSaverSharp.Models
+{
+    public class Curator : IEquatable<Curator>
+    {
+        /// <summary>
+        /// Id of the curator.
+        /// </summary>
+        [JsonProperty("id")]
+        public int Id { get; internal set; }
+
+        /// <summary>
+        /// Name of the curator.
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; internal set; } = null!;
+
+        /// <summary>
+        /// Link of the avatar of the curator.
+        /// </summary>
+        [JsonProperty("avatar")]
+        public string Avatar { get; internal set; } = null!;
+
+        /// <summary>
+        /// User account type of the curator.
+        /// </summary>
+        [JsonProperty("type")]
+        public string Type { get; internal set; } = null!;
+
+        internal Curator() { }
+        
+        // Equality Methods
+
+        public bool Equals(Curator? other) => Id == other?.Id;
+        public override int GetHashCode() => Id.GetHashCode();
+        public override bool Equals(object? obj) => Equals(obj as Curator);
+        public static bool operator ==(Curator left, Curator right) => Equals(left, right);
+        public static bool operator !=(Curator left, Curator right) => !Equals(left, right);
+    }
+}


### PR DESCRIPTION
The Beatmap Curator property got changed from a nullable string to an actual object.
Example API call: https://api.beatsaver.com/maps/hash/3c1add30fc9cc633d1097ad5cd5ee78a5572733c

This PR adds (initial?) support for that.