### PR TITLE
Support for the Legacy characteristic

### DIFF
--- a/BeatSaverSharp/Models/BeatmapDifficulty.cs
+++ b/BeatSaverSharp/Models/BeatmapDifficulty.cs
@@ -125,7 +125,8 @@ namespace BeatSaverSharp.Models
             _360Degree,
 
             Lightshow,
-            Lawless
+            Lawless,
+            Legacy
         }
 
         public enum BeatSaverBeatmapDifficulty


### PR DESCRIPTION
This new characteristic has been added in 1.31.0 and causes BeatSaverSharp to fail when it encounters a map that uses it:

![image](https://github.com/Auros/BeatSaverSharper/assets/793322/227ff1bf-1eb9-473e-b620-418d7daa292b)

I didn't bump the version but I can if that's easier for you.
